### PR TITLE
Correct the version to being 0.11.0-dev

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from skbuild import setup
 
 setup(
     name='SimpleITK',
-    version='0.11.0',
+    version='0.11.0-dev',
     author='Insight Software Consortium',
     author_email='insight-users@itk.org',
     packages=['SimpleITK'],


### PR DESCRIPTION
SimpleITK 0.11 has not been release. This package can not be marked as
that release yet. Marking it as dev follows PEP 440, to indicate that
it is before the release. This version omits a number which PEP 440
implicitly interprets as 0.