### PR TITLE
Fix intra-external project dependencies with update step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,8 @@ if(SimpleITKPythonPackage_SUPERBUILD)
       DEPENDS SimpleITK-download
       )
 
+    ExternalProject_Add_StepDependencies(SimpleITK-superbuild download SimpleITK-download)
+
     set(SimpleITK_DIR ${SimpleITK_SUPERBUILD_DIR}/SimpleITK-build)
     if(WIN32)
       set(SWIG_TARGET_VERSION "3.0.10")
@@ -229,6 +231,8 @@ if(SimpleITKPythonPackage_SUPERBUILD)
     )
 
   message(STATUS "SuperBuild -   SimpleITK_PYTHON_DIR: ${SimpleITK_PYTHON_DIR}")
+
+  ExternalProject_Add_StepDependencies(SimpleITK-python download SimpleITK-download)
 
 
   #-----------------------------------------------------------------------------


### PR DESCRIPTION
With CMake 3.6.2, the empty patch step is run before external project
dependencies are satisfied. With CMake 3.2 the
ExternalProject_Add_StepDependencies method was added to allow the
first step in an external project, the download step, to have a
dependencies.

This patch addressed build failures during the
"SimpleITK-python-update" step.