### PR TITLE
Shorted build path to allow ITK to build on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ if(SimpleITKPythonPackage_SUPERBUILD)
 
   if(NOT DEFINED SimpleITK_DIR AND NOT DEFINED SWIG_EXECUTABLE)
 
-    set(SimpleITK_SUPERBUILD_DIR ${CMAKE_BINARY_DIR}/SimpleITK-superbuild)
+    set(SimpleITK_SUPERBUILD_DIR ${CMAKE_BINARY_DIR}/sitk-sb)
 
     ExternalProject_add(SimpleITK-superbuild
       SOURCE_DIR ${SimpleITK_SOURCE_DIR}/SuperBuild


### PR DESCRIPTION
Addresses the following build error:
loading initial cache file
C:/d/p/_skbuild/cmake-build/SimpleITK-superbuild/ITK-build/CMakeCacheInit.txt
CMake Error at CMakeLists.txt:30 (message):
ITK source code directory path length is too long (52 > 50).Please
move the ITK source code directory to a directory with a shorter path.

Addressed #22 