### PR TITLE
Correct package version for PEP 440 compliance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from skbuild import setup
 
 setup(
     name='SimpleITK',
-    version='0.11.0-dev',
+    version='0.11.0.dev',
     author='Insight Software Consortium',
     author_email='insight-users@itk.org',
     packages=['SimpleITK'],


### PR DESCRIPTION
The invalid `-` deliminator was used in stead of `+` for a local
version identifier. However for the `dev` component just the `.`
deliminator is needed.