### PR TITLE
Add explicit setup requirement for scikit-build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include CMakeLists.txt
+include README.md
+include setup.py
+include requirements.txt
+graft SimpleITK
+prune SimpleITK/.ExternalData
+prune _skbuild

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,15 @@
-from skbuild import setup
+try:
+    from skbuild import setup
+except ImportError:
+    try:
+        from setuptools import setup
+    except ImportError:
+        print('setuptools or scikit-build is required to build from source.', file=sys.stderr)
+        print('Please run:\n', file=sys.stderr)
+        print('  python -m pip install setuptools')
+        sys.exit(1)
+
+
 
 setup(
     name='SimpleITK',
@@ -22,6 +33,6 @@ setup(
     license='Apache',
     keywords='ITK InsightToolkit segmentation registration image',
     url=r'http://simpleitk.org/',
-    install_requires=[
-    ]
+    install_requires=[],
+    setup_requires=['scikit-build>=0.5']
     )


### PR DESCRIPTION
Fallback to setuptools when scikit-build is not available to allow the
egg_info command to specify the requirements to run setup.py. This
allows source distribution to specify that they require scikit-build.