### PR TITLE
Reverting change to setup.py to allow egg_info without scikit_build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,11 @@ from os import sys
 try:
     from skbuild import setup
 except ImportError:
-    try:
-        from setuptools import setup
-    except ImportError:
-        print('setuptools or scikit-build is required to build from source.', file=sys.stderr)
-        print('Please run:\n', file=sys.stderr)
-        print('  python -m pip install setuptools')
-        sys.exit(1)
-
+    print('scikit-build is required to build from source.', file=sys.stderr)
+    print('Please run:', file=sys.stderr)
+    print('', file=sys.stderr)
+    print('  python -m pip install scikit-build')
+    sys.exit(1)
 
 
 setup(
@@ -46,6 +43,5 @@ setup(
     keywords='ITK InsightToolkit segmentation registration image',
     url=r'http://simpleitk.org/',
     install_requires=[],
-    setup_requires=['scikit-build>=0.5'],
     zip_safe=False
     )


### PR DESCRIPTION
The "setup_requires" parameter does not always work properly to
install scikit_build before compiling SimpleITK. We are reverting to
checking if the required scikit_build package is installed and
producing a instructional error message if it is not available.