### PR TITLE
Explicitly use mac-15-intel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,8 +46,8 @@ jobs:
     needs: package
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.13']
+        os: [ubuntu-latest, macos-15-intel]
+        python-version: ['3.10', '3.14']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/download-artifact@v4.3.0


### PR DESCRIPTION
The GHA hosted ARM does not have enough memory to efficiently build 2.x SimpleITK. There is a fix in SimpleITK 3.x that reduces the peak memory usage.